### PR TITLE
Add blog post: PZ74–PZ79 support for standard DNA residue names and update site indexes

### DIFF
--- a/blog/2026/04/02/PZ74-PZ79-Update-Support-for-Standard-DNA-Residue-Names/index.html
+++ b/blog/2026/04/02/PZ74-PZ79-Update-Support-for-Standard-DNA-Residue-Names/index.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>RNA-Puzzles</title>
+  <title>PZ74–PZ79 Update: Support for Standard DNA Residue Names - RNA-Puzzles</title>
   <meta name="author" content="Chichau Miao">
 
   
@@ -14,16 +14,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   
-  <link rel="canonical" href="http://www.rnapuzzles.org/">
+  <link rel="canonical" href="http://www.rnapuzzles.org/blog/2023/10/07/Submission%20Process/">
   <link href="/favicon.png" type="image/png" rel="icon">
   <link href="/atom.xml" rel="alternate" title="RNA-Puzzles" type="application/atom+xml">
 
   <!-- http://opengraphprotocol.org/ -->
   <meta name="twitter:card" content="summary_large_image">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="http://www.rnapuzzles.org/">
-  <meta property="og:title" content="RNA-Puzzles">
-  <meta property="og:description" content="RNA-Puzzles a community-wide blind evaluation of RNA 3D structure prediction.">
+  <meta property="og:url" content="http://www.rnapuzzles.org/blog/2023/10/07/Submission%20Process/">
+  <meta property="og:title" content="PZ74–PZ79 Update: Support for Standard DNA Residue Names - RNA-Puzzles">
+  
 
   <script src="/assets/bootstrap/dist/js/jquery-3.2.1.min.js"></script>
 
@@ -127,56 +127,79 @@
       <div id="main" role="main" class="container">
         <div id="content">
           <div class="row">
-<div class="page-content col-md-9">
-<div class="blog-index" itemscope itemtype="http://schema.org/Blog">
+  <div class="page-content col-md-9" itemscope itemtype="http://schema.org/Blog">
     <meta itemprop="name" content="RNA-Puzzles" />
     <meta itemprop="description" content="RNA-Puzzles a community-wide blind evaluation of RNA 3D structure prediction." />
     <meta itemprop="url" content="http://www.rnapuzzles.org" />
-
-
-<h2>RNA-Puzzles</h2> is a collective experiment for blind RNA structure prediction.<br/>
-
-The sequence of a solved RNA structure is confidentially communicated to participating modelling groups a couple of weeks prior to publication. The results are assessed and presented in common publications involving structuralists and modellers.</br>
-<hr/>
+    <article class="hentry" role="article" itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting">
+      
+  <header class="page-header">
     
-<div class="panel panel-info">
-	<div class="panel-heading">
-	    <h3 class="panel-title">Aims of the project</h3>
-	</div>
-	<li>To determine the capabilities and limitations of current computational methods of 3D RNA structure prediction based on sequence;</li>
-	<li>To assess progress made and to improve assessment protocols and methods;</li>
-	<li>To identify whether there are specific bottlenecks that hold back progress;</li>
-	<li>To promote the available methods and guide potential users in the choice of suitable tools;</li>
-	<li>To encourage the RNA structure prediction community in their efforts to improve the current tools and to make automated prediction tools available;</li>
-	<li>To explore the underlying mechanism of ligand-RNA binding and associated conformational changes.</li>
+      <p class="meta text-muted text-uppercase">
+<!--
+        
+
+
+
+
+
+
+
+
+
+
+
+
+<span class="glyphicon glyphicon-calendar"></span> <time datetime="2026-04-02T00:00:00+00:00"  data-updated="true" itemprop="datePublished dateCreated">ordinal</time>
+-->
+        
+      </p>
+    
+    
+    <h1 class="entry-title" itemprop="name headline">
+        PZ74–PZ79 Update: Support for Standard DNA Residue Names
+        
+    </h1>
+    
+  </header>
+
+
+<div class="entry-content clearfix" itemprop="articleBody description"><p>We have updated PZ74–PZ79 to support standard DNA residue names in submitted structure files.</p>
+
+<p>For these puzzles, the recommended DNA residue names are DA, DC, DG, and DT, in line with standard PDB nomenclature for deoxyribonucleotides.</p>
+
+<p>To avoid disrupting ongoing submissions, we will also temporarily accept legacy single-letter residue names such as A, C, G, and T when they are used to represent DNA in these puzzles. Because such naming can be ambiguous with RNA, this compatibility is being maintained only for the current transition period.</p>
+
+<p>In future RNA-Puzzles challenges, DNA and RNA residue nomenclature and polymer identity will be handled more explicitly during submission and validation.</p>
+
+<p>We thank Naeim Moafinejad of the International Institute of Molecular and Cell Biology in Warsaw (IIMCB) for bringing this issue to our attention. Progress in the field depends on careful feedback from engaged members of the community.</p>
+
+<p>Thank you for your continued support of RNA-Puzzles.</p>
 </div>
 
-<div class="panel panel-info">
-    <div class="panel-heading"><h3 class="panel-title">Basic Rules <a style="color:red">(PLEASE READ CAREFULLY)</a></h3></div>
-	<li>Confidential agreement required from new users: "I will use the provided sequence data for prediction purposes only. I will not distribute the sequences in any form outside my working group."</li>
-	<li>It is strongly recommended to avoid assessment error that all the predictions be formatted in standard <b><a href="https://cdn.rcsb.org/wwpdb/docs/documentation/file-format/PDB_format_1992.pdf">PDB format</a></b>. We provide a python script <b><a href="https://chichaumiau.github.io/RNA-Puzzles_format/">here</a></b> for generating standard PDB format files into which the coordinates need to be replaced by the predictors. </li>
-	<li>Please name the submission file without space in the file name. The suggested names are: PZ#_Method.pdb for web servers and PZ#_GroupName.pdb for human predictors. </li>
-	<li>RNA chains should be named in alphabetical order: A for the first chain, B for the second chain, and so on. </li>
-	<li>Up to <b>FIVE</b> prediction models should be submitted as the final results for each puzzle from each prediction method. Each prediction group can submit results from several prediction methods (automatic or manual, etc.). </li>
-	<li>Please put all prediction models together in one PDB file as in the NMR format (Separate models by lines: "MODEL n" and "ENDMDL").  </li>
-	<li>For submission, please either use the online <a href="http://www.rnapuzzles.org/open-puzzle/">registration and submission</a> portal (see the open-puzzle tag: http://www.rnapuzzles.org/open-puzzle/) or send us an <b><a href="mailto:e.westhof@ibmc-cnrs.unistra.fr?cc=ibmc.cnrs@gmail.com&amp;subject=RNA-Puzzles%20Submission">email</a></b>  (Please send an email to e.westhof@ibmc-cnrs.unistra.fr and cc. ibmc.cnrs@gmail.com).</li>
-    <li>For structure comparison metrics, please refer to RNA-Puzzles toolkit at <a href="https://chichaumiau.github.io/rnapuzzlestoolkit">https://chichaumiau.github.io/rnapuzzlestoolkit</a>. Please find the reference at <a href="https://pubmed.ncbi.nlm.nih.gov/31799609/">Nucleic Acids Res. 2020 Jan 24;48(2):576-588</a>. To use evaluation metrics in CASP15, please also refer to the repos: <a href="https://github.com/DasLab/casp-rna">https://github.com/DasLab/casp-rna</a> and <a href="https://github.com/DasLab/CASP15_RNA_EM">https://github.com/DasLab/CASP15_RNA_EM</a>. The reference can be found at <a href="">biorxiv</a>.</li>
-</div>
-<div class="panel panel-info">
-	<div class="panel-heading"><h3 class="panel-title">Call for participants</h3></div>
-        <li>We hope more structural biologists can help us in providing more crystallographic, cryo-EM or NMR structures. Any kind of RNA related structure information is encouraged. Anyone who may have a RNA structure ready for publication please contact <a href="mailto:e.westhof@ibmc-cnrs.unistra.fr?cc=ibmc.cnrs@gmail.com&amp;subject=[RNA-Puzzles]%20Structure%20Provide">us</a> (Please send an email to e.westhof@ibmc-cnrs.unistra.fr and cc. ibmc.cnrs@gmail.com).</li>
-        <li>We encourage more predictors who are interested in RNA structure prediction to take part in this compitition to push forward the field. Anyone who is interested please send us an <a href="mailto:e.westhof@ibmc-cnrs.unistra.fr?subject=[Help]%20RNA-Puzzles&cc=ibmc.cnrs@gmail.com">email</a> (Please send an email to e.westhof@ibmc-cnrs.unistra.fr and cc. ibmc.cnrs@gmail.com).</li>
-</div>
 
-<div class="panel panel-info">
-	<div class="panel-heading"><h3 class="panel-title">Updates</h3></div>
-	<div class="list-group">
-      
-      
-      
-        <article class="list-group-item ">
+      <footer>
+        <p class="meta text-muted">
+          
+  
+
+<span class="glyphicon glyphicon-user"></span> <span class="byline author vcard" itemprop="author" itemscope itemtype="http://schema.org/Person">Posted by <span class="fn" itemprop="name">Chichau Miao</span></span>
+
           
 
+
+
+
+
+
+
+
+
+
+
+
+<span class="glyphicon glyphicon-calendar"></span> <time datetime="2026-04-02T00:00:00+00:00"  data-updated="true" itemprop="datePublished dateCreated">ordinal</time>
+          
 
 <span class="glyphicon glyphicon-tags"></span>&nbsp;
 <span class="categories">
@@ -185,200 +208,33 @@ The sequence of a solved RNA structure is confidentially communicated to partici
   
 </span>
 
- &nbsp;&nbsp;&nbsp;
-<a href="/blog/2026/04/02/PZ74-PZ79-Update-Support-for-Standard-DNA-Residue-Names/" itemprop="url">PZ74–PZ79 Update: Support for Standard DNA Residue Names</a>
 
-
-        </article>
-      
-              <article class="list-group-item ">
-          
-
-
-<span class="glyphicon glyphicon-tags"></span>&nbsp;
-<span class="categories">
+        </p>
+        
+          <div class="sharing">
   
-    <a class='category' href='/blog/categories/news/'>news</a>
   
-</span>
-
- &nbsp;&nbsp;&nbsp;
-<a href="/blog/2023/10/07/Submission%20Process/" itemprop="url">Submission Process</a>
-
-
-        </article>
-      
-      
-        <article class="list-group-item ">
-          
-
-
-<span class="glyphicon glyphicon-tags"></span>&nbsp;
-<span class="categories">
   
-    <a class='category' href='/blog/categories/news/'>news</a>
-  
-</span>
-
- &nbsp;&nbsp;&nbsp;
-<a href="/blog/2023/10/07/Research-Spectrum/" itemprop="url">Research Spectrum</a>
-
-
-        </article>
-      
-      
-        <article class="list-group-item ">
-          
-
-
-<span class="glyphicon glyphicon-tags"></span>&nbsp;
-<span class="categories">
-  
-    <a class='category' href='/blog/categories/news/'>news</a>
-  
-</span>
-
- &nbsp;&nbsp;&nbsp;
-<a href="/blog/2023/10/07/Recent-Engagements/" itemprop="url">Recent Engagements</a>
-
-
-        </article>
-      
-      
-        <article class="list-group-item ">
-          
-
-
-<span class="glyphicon glyphicon-tags"></span>&nbsp;
-<span class="categories">
-  
-    <a class='category' href='/blog/categories/news/'>news</a>
-  
-</span>
-
- &nbsp;&nbsp;&nbsp;
-<a href="/blog/2023/10/07/Participating-Teams/" itemprop="url">Participating Teams</a>
-
-
-        </article>
-      
-      
-        <article class="list-group-item ">
-          
-
-
-<span class="glyphicon glyphicon-tags"></span>&nbsp;
-<span class="categories">
-  
-    <a class='category' href='/blog/categories/news/'>news</a>
-  
-</span>
-
- &nbsp;&nbsp;&nbsp;
-<a href="/blog/2023/10/07/Methodological-Progress/" itemprop="url">Methodological Progress</a>
-
-
-        </article>
-      
-      
-        <article class="list-group-item ">
-          
-
-
-<span class="glyphicon glyphicon-tags"></span>&nbsp;
-<span class="categories">
-  
-    <a class='category' href='/blog/categories/news/'>news</a>
-  
-</span>
-
- &nbsp;&nbsp;&nbsp;
-<a href="/blog/2023/10/07/Future%20Outlook/" itemprop="url">Future Outlook</a>
-
-
-        </article>
-      
-      
-        <article class="list-group-item ">
-          
-
-
-<span class="glyphicon glyphicon-tags"></span>&nbsp;
-<span class="categories">
-  
-    <a class='category' href='/blog/categories/results/'>results</a>
-  
-</span>
-
- &nbsp;&nbsp;&nbsp;
-<a href="/blog/2017/11/18/PZ39/" itemprop="url">Puzzle 39</a>
-
-
-        </article>
-      
-      
-        <article class="list-group-item ">
-          
-
-
-<span class="glyphicon glyphicon-tags"></span>&nbsp;
-<span class="categories">
-  
-    <a class='category' href='/blog/categories/results/'>results</a>
-  
-</span>
-
- &nbsp;&nbsp;&nbsp;
-<a href="/blog/2017/11/18/PZ38/" itemprop="url">Puzzle 38</a>
-
-
-        </article>
-      
-      
-        <article class="list-group-item ">
-          
-
-
-<span class="glyphicon glyphicon-tags"></span>&nbsp;
-<span class="categories">
-  
-    <a class='category' href='/blog/categories/results/'>results</a>
-  
-</span>
-
- &nbsp;&nbsp;&nbsp;
-<a href="/blog/2017/11/18/PZ37/" itemprop="url">Puzzle 37</a>
-
-
-        </article>
-      
-      
-        <article class="list-group-item ">
-          
-
-
-<span class="glyphicon glyphicon-tags"></span>&nbsp;
-<span class="categories">
-  
-    <a class='category' href='/blog/categories/results/'>results</a>
-  
-</span>
-
- &nbsp;&nbsp;&nbsp;
-<a href="/blog/2017/11/18/PZ36/" itemprop="url">Puzzle 36</a>
-
-
-        </article>
-      
-     </div>
-</div>
-</div>
 </div>
 
+        
+        
+          <ul class="meta text-muted pager">
+            
+            <li class="previous"><a href="/blog/2023/10/07/Submission%20Process/" title="Previous Post: Submission Process">&laquo; Submission Process</a></li>
+            
+            
+          </ul>
+        
+      </footer>
+    </article>
+    
+  </div>
+
   
-    <aside class="sidebar col-md-3">
-      
-        <section>
+  <aside class="sidebar col-md-3">
+    
+      <section>
   <h1>RNA-Puzzles</h1>
   <p>A collective blind evaluation of RNA three-dimensional structure prediction</p>
 	<a href="https://github.com/RNA-Puzzles"><i class="fa fa-github-square fa-fw fa-2x"></i></a>
@@ -395,6 +251,8 @@ The sequence of a solved RNA structure is confidentially communicated to partici
   </div>
   
   <div id="recent_posts" class="list-group">
+    
+    <a class="list-group-item active" href="/blog/2026/04/02/PZ74-PZ79-Update-Support-for-Standard-DNA-Residue-Names/">PZ74–PZ79 Update: Support for Standard DNA Residue Names</a>
     
     <a class="list-group-item " href="/blog/2023/10/07/Submission%20Process/">Submission Process</a>
     
@@ -447,7 +305,7 @@ The sequence of a solved RNA structure is confidentially communicated to partici
       <h3 class="panel-title">Categories</h3>
   </div>
     <div class='list-group-item'><a href='/blog/categories/group/'>group (16)</a></div>
-<div class='list-group-item'><a href='/blog/categories/news/'>news (8)</a></div>
+<div class='list-group-item'><a href='/blog/categories/news/'>news (7)</a></div>
 <div class='list-group-item'><a href='/blog/categories/results/'>results (39)</a></div>
 <div class='list-group-item'><a href='/blog/categories/table/'>table (66)</a></div>
 
@@ -469,8 +327,8 @@ The sequence of a solved RNA structure is confidentially communicated to partici
 
 
 
-      
-    </aside>
+    
+  </aside>
   
 </div>
 
@@ -488,19 +346,6 @@ The sequence of a solved RNA structure is confidentially communicated to partici
 </div>
 </footer>
     
-
-<script type="text/javascript">
-      var disqus_shortname = 'rna-puzzles';
-      
-        
-        var disqus_script = 'count.js';
-      
-    (function () {
-      var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = '//' + disqus_shortname + '.disqus.com/' + disqus_script;
-      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-    }());
-</script>
 
 
 

--- a/blog/categories/news/index.html
+++ b/blog/categories/news/index.html
@@ -149,6 +149,42 @@
 
 
   
+  <h2 class="year">2026</h2>
+
+<article class="page-header" itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting">
+  
+<h2 class="post-title" itemprop="name headline"><a href="/blog/2026/04/02/PZ74-PZ79-Update-Support-for-Standard-DNA-Residue-Names/" itemprop="url">PZ74–PZ79 Update: Support for Standard DNA Residue Names</a></h2>
+<p class="meta text-muted">
+<!--
+  
+
+
+
+
+
+
+
+
+
+
+
+-->
+  
+
+<span class="glyphicon glyphicon-tags"></span>&nbsp;
+<span class="categories">
+  
+    <a class='category' href='/blog/categories/news/'>news</a>
+  
+</span>
+
+
+</p>
+
+</article>
+
+
+
   <h2 class="year">2023</h2>
 
 <article class="page-header" itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting">
@@ -484,7 +520,7 @@
       <h3 class="panel-title">Categories</h3>
   </div>
     <div class='list-group-item'><a href='/blog/categories/group/'>group (16)</a></div>
-<div class='list-group-item'><a href='/blog/categories/news/'>news (7)</a></div>
+<div class='list-group-item'><a href='/blog/categories/news/'>news (8)</a></div>
 <div class='list-group-item'><a href='/blog/categories/results/'>results (39)</a></div>
 <div class='list-group-item'><a href='/blog/categories/table/'>table (66)</a></div>
 

--- a/news/index.html
+++ b/news/index.html
@@ -165,6 +165,42 @@
 
 
   
+  <h2 class="year">2026</h2>
+
+<article class="page-header" itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting">
+  
+<h2 class="post-title" itemprop="name headline"><a href="/blog/2026/04/02/PZ74-PZ79-Update-Support-for-Standard-DNA-Residue-Names/" itemprop="url">PZ74–PZ79 Update: Support for Standard DNA Residue Names</a></h2>
+<p class="meta text-muted">
+<!--
+  
+
+
+
+
+
+
+
+
+
+
+
+-->
+  
+
+<span class="glyphicon glyphicon-tags"></span>&nbsp;
+<span class="categories">
+  
+    <a class='category' href='/blog/categories/news/'>news</a>
+  
+</span>
+
+
+</p>
+
+</article>
+
+
+
   <h2 class="year">2023</h2>
 
 <article class="page-header" itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting">
@@ -522,7 +558,7 @@
       <h3 class="panel-title">Categories</h3>
   </div>
     <div class='list-group-item'><a href='/blog/categories/group/'>group (16)</a></div>
-<div class='list-group-item'><a href='/blog/categories/news/'>news (7)</a></div>
+<div class='list-group-item'><a href='/blog/categories/news/'>news (8)</a></div>
 <div class='list-group-item'><a href='/blog/categories/results/'>results (39)</a></div>
 <div class='list-group-item'><a href='/blog/categories/table/'>table (66)</a></div>
 


### PR DESCRIPTION
### Motivation
- Announce that puzzles PZ74–PZ79 now support standard DNA residue names (`DA`, `DC`, `DG`, `DT`) while temporarily accepting legacy single-letter DNA residue names for compatibility.
- Update the site navigation and archive pages so the new post is discoverable in the `news` category and on the homepage.

### Description
- Add new blog post HTML at `blog/2026/04/02/PZ74-PZ79-Update-Support-for-Standard-DNA-Residue-Names/index.html` describing the naming change and transition policy. 
- Insert the new post entry into the `news` and `news`-category archive pages by updating `blog/categories/news/index.html` and `news/index.html` to include a 2026 heading and the new post link. 
- Add the new post link to the homepage `index.html` Updates list and increment the displayed `news` count from 7 to 8 in the site sidebars. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce3427ae40832a883b2289e5a57dd3)