### PR TITLE
Add news: PZ74–PZ79 support for standard DNA residue names

### DIFF
--- a/_includes/news.html
+++ b/_includes/news.html
@@ -39,6 +39,7 @@
 			<h3 class="panel-title">Recent Posts</h3>
 		</div>
 		<div id="recent_posts" class="list-group">
+			<a class="list-group-item" href="/news/2026/04/02/PZ74-PZ79-Update-Standard-DNA-Residue-Names.html">PZ74–PZ79 Update: Support for Standard DNA Residue Names</a>
 			<a class="list-group-item" href="/news/2023/10/07/Submission-Process.html">Submission Process</a>
 			<a class="list-group-item" href="/news/2023/10/07/Research-Spectrum.html">Research Spectrum</a>
 			<a class="list-group-item" href="/news/2023/10/07/Recent-Engagements.html">Recent Engagements</a>
@@ -92,7 +93,7 @@
 			<a href="/blog/group_category/">group (16)</a>
 		</div>
 		<div class="list-group-item">
-			<a href="/blog/news_category/">news (7)</a>
+			<a href="/blog/news_category/">news (8)</a>
 		</div>
 		<div class="list-group-item">
 			<a href="/blog/results_category/">results (39)</a>

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -112,7 +112,15 @@ permalink: /
                     <article class="list-group-item">
                       <span class="glyphicon glyphicon-tags"></span>&nbsp;
                       <span class="categories">
-                        <a class="category" href="ç">news</a>
+                        <a class="category" href="/blog/news_category/">news</a>
+                      </span>
+                      &nbsp;&nbsp;&nbsp;
+                      <a href="/news/2026/04/02/PZ74-PZ79-Update-Standard-DNA-Residue-Names.html" itemprop="url">PZ74–PZ79 Update: Support for Standard DNA Residue Names</a>
+                    </article>
+                    <article class="list-group-item">
+                      <span class="glyphicon glyphicon-tags"></span>&nbsp;
+                      <span class="categories">
+                        <a class="category" href="/blog/news_category/">news</a>
                       </span>
                       &nbsp;&nbsp;&nbsp;
                       <a href="/news/2023/10/07/Submission-Process.html" itemprop="url">Submission Process</a>

--- a/_posts/news/2026-04-02-PZ74-PZ79-Update-Standard-DNA-Residue-Names.markdown
+++ b/_posts/news/2026-04-02-PZ74-PZ79-Update-Standard-DNA-Residue-Names.markdown
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "PZ74–PZ79 Update: Support for Standard DNA Residue Names"
+date: 2026-04-02 00:00:00 +0000
+comments: false
+categories:
+- news
+---
+
+We have updated PZ74–PZ79 to support standard DNA residue names in submitted structure files.
+
+For these puzzles, the recommended DNA residue names are DA, DC, DG, and DT, in line with standard PDB nomenclature for deoxyribonucleotides.
+
+To avoid disrupting ongoing submissions, we will also temporarily accept legacy single-letter residue names such as A, C, G, and T when they are used to represent DNA in these puzzles. Because such naming can be ambiguous with RNA, this compatibility is being maintained only for the current transition period.
+
+In future RNA-Puzzles challenges, DNA and RNA residue nomenclature and polymer identity will be handled more explicitly during submission and validation.
+
+We thank Naeim Moafinejad of the International Institute of Molecular and Cell Biology in Warsaw (IIMCB) for bringing this issue to our attention. Progress in the field depends on careful feedback from engaged members of the community.
+
+Thank you for your continued support of RNA-Puzzles.


### PR DESCRIPTION
### Motivation
- Announce that PZ74–PZ79 now support standard DNA residue names (DA/DC/DG/DT) and provide a temporary compatibility note for legacy single-letter names to avoid disrupting ongoing submissions.

### Description
- Add new post ` _posts/news/2026-04-02-PZ74-PZ79-Update-Standard-DNA-Residue-Names.markdown` with the supplied announcement and update ` _pages/home.md` and ` _includes/news.html` to list the new item in the Updates panel and Recent Posts and increment the news count to `8`.

### Testing
- No automated tests were run because this is a documentation/content-only change per repository policy; changes were committed and the new/modified files were verified in the working tree (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce3d22d658832a9420d14f3e45adf2)